### PR TITLE
Change the usability testing api call

### DIFF
--- a/lib/loon/jobs/usability_testing.ex
+++ b/lib/loon/jobs/usability_testing.ex
@@ -10,7 +10,7 @@ defmodule Loon.Jobs.UsabilityTesting do
   """
   def job() do
     token = Map.fetch!(System.get_env(), "AIRTABLE_DASHBOARD_KEY")
-    url = "https://api.airtable.com/v0/appwJrZHgj8Ijew93/Studies"
+    url = "https://api.airtable.com/v0/appwJrZHgj8Ijew93/Studies?cellFormat=string&timeZone=America/Toronto&userLocale=en-ca"
     headers = ["Authorization": "Bearer #{token}", "Accept": "Application/json"]
 
     case HTTPoison.get(url, headers) do


### PR DESCRIPTION
I added query params so that fields containing linked records will have the linked content strings rather than rec ids. 